### PR TITLE
Fall back to check_cxx_source_compiles when cross-compiling

### DIFF
--- a/modules/FindFilesystem.cmake
+++ b/modules/FindFilesystem.cmake
@@ -116,7 +116,7 @@ if(CMAKE_CROSSCOMPILING)
     endmacro()
 else()
     include(CheckCXXSourceRuns)
-    macro(check_cxx_source code var)
+    macro(_cmcm_check_cxx_source code var)
         check_cxx_source_runs("${code}" ${var})
     endmacro()
 endif()
@@ -205,7 +205,7 @@ if(CXX_FILESYSTEM_HAVE_FS)
     ]] code @ONLY)
 
     # Check a simple filesystem program without any linker flags
-    check_cxx_source("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+    _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
 
     set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
 
@@ -213,12 +213,12 @@ if(CXX_FILESYSTEM_HAVE_FS)
         set(prev_libraries ${CMAKE_REQUIRED_LIBRARIES})
         # Add the libstdc++ flag
         set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs)
-        check_cxx_source("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
         set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
         if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
             # Try the libc++ flag
             set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
-            check_cxx_source("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
             set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
         endif()
     endif()

--- a/modules/FindFilesystem.cmake
+++ b/modules/FindFilesystem.cmake
@@ -111,7 +111,7 @@ include(CheckIncludeFileCXX)
 # Otherwise, assume that compile + link is a sufficient check.
 if(CMAKE_CROSSCOMPILING)
     include(CheckCXXSourceCompiles)
-    macro(check_cxx_source code var)
+    macro(_cmcm_check_cxx_source code var)
         check_cxx_source_compiles("${code}" ${var})
     endmacro()
 else()


### PR DESCRIPTION
On certain systems, code using std::fs can appear to link successfully
but fail at runtime. But always checking the runtime result of the check
executable precludes cross-compilation. So now when cross-compiling, we
only check that the test executable compiles - otherwise, we try to run
the resulting executable as well.

Fixes #10